### PR TITLE
feat(iast): accept ń (U+0144) as input alias for velar nasal ṅ

### DIFF
--- a/src/encoding_mappings.py
+++ b/src/encoding_mappings.py
@@ -75,6 +75,14 @@ GAURA_TIMES = (
 ASPIRATED_CYRILLIC_LETTERS = ("к", "ґ", "ч", "ж", "т̣", "д̣", "т", "д", "п", "б")
 ASPIRATED_ROMAN_LETTERS = ("k", "g", "c", "j", "ṭ", "ḍ", "t", "d", "p", "b")
 
+# Non-standard look-alikes that show up in real IAST input (e.g. Gaudiya Vaiṣṇava
+# song texts), mapped to their canonical IAST form. Applied to the input string
+# only; the output stays canonical. See issue #9.
+IAST_INPUT_ALIASES = {
+    "ń": "ṅ",  # U+0144 LATIN SMALL LETTER N WITH ACUTE -> U+1E45 (velar nasal)
+    "Ń": "Ṅ",  # U+0143 -> U+1E44
+}
+
 
 # ENUMS
 class Encodings(Enum):

--- a/src/service.py
+++ b/src/service.py
@@ -1,6 +1,7 @@
 from encoding_mappings import (
     ASPIRATED_CYRILLIC_LETTERS,
     ASPIRATED_ROMAN_LETTERS,
+    IAST_INPUT_ALIASES,
     RUSSIAN_ENCODINGS,
     Encodings,
 )
@@ -30,6 +31,12 @@ def convert(
 
     if input_encoding == output_encoding:
         return string
+
+    # Normalize common non-standard IAST look-alikes to their canonical form before
+    # matching (e.g. "ń" U+0144 used for the velar nasal "ṅ" U+1E45 in many song texts).
+    if input_encoding == Encodings.IAST.value:
+        for wrong, right in IAST_INPUT_ALIASES.items():
+            string = string.replace(wrong, right)
 
     # Build a lookup so we can translate in a single left-to-right pass.
     # str.replace() in a loop causes collisions when one encoding reuses a

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -380,3 +380,35 @@ class TestEdgeCases:
 
     def test_newline_preserved(self):
         assert convert("kṛṣṇa\nrāma", IAST, BALARAM, I, B) == "kåñëa\nräma"
+
+
+# ---------------------------------------------------------------------------
+# Non-standard IAST look-alikes on input (issue #9)
+#
+# Many Gaudiya Vaiṣṇava song texts write the velar nasal ṅ (U+1E45) as the
+# Polish-style ń (U+0144). It must be accepted as an input alias for ṅ, while
+# the output stays canonical.
+# ---------------------------------------------------------------------------
+
+class TestIastInputAliases:
+
+    def test_n_acute_alias_to_iast(self):
+        # ń (U+0144) on input behaves exactly like ṅ (U+1E45)
+        assert convert("sańge", IAST_EXT, IAST_EXT, I, I) == "sańge"  # same-encoding short-circuit
+        assert convert("sańge", IAST_EXT, BALARAM_EXT, I, B) == convert("saṅge", IAST_EXT, BALARAM_EXT, I, B)
+
+    def test_n_acute_alias_to_rus(self):
+        assert convert("sańge", IAST_EXT, RUS, I, R) == "сан̇ге"
+
+    def test_capital_n_acute_alias(self):
+        assert convert("ŃA", IAST_EXT, RUS, I, R) == convert("ṄA", IAST_EXT, RUS, I, R)
+
+    def test_full_verse_line(self):
+        # "prabhu lokanātha kobe sańge loyā jābe" — no Latin ń must survive
+        out = convert("prabhu lokanātha kobe sańge loyā jābe", IAST_EXT, RUS, I, R)
+        assert "ń" not in out
+        assert "сан̇ге" in out
+
+    def test_alias_not_applied_for_non_iast_input(self):
+        # A stray ń in non-IAST input is left untouched (не our alias's job)
+        assert "ń" in convert("sańge", BALARAM_EXT, RUS, B, R)


### PR DESCRIPTION
## Summary

Closes #9. IAST input that writes the velar nasal as `ń` (U+0144) instead of `ṅ` (U+1E45) now converts correctly.

## Root cause

`ń` = U+0144 (LATIN SMALL LETTER N WITH ACUTE) looks like the IAST velar nasal `ṅ` = U+1E45 (N WITH DOT ABOVE) but is a different codepoint, present in none of the seven schemes. It therefore fell through the position-based matcher untouched:

```
IAST 'sańge' (ń = U+0144)  →  RUS 'саńге'   ✗  (before)
IAST 'saṅge' (ṅ = U+1E45)  →  RUS 'сан̇ге'   ✓
```

`ń` for ṅ is a widespread convention in Gaudiya Vaiṣṇava song texts and bhajana books online, and for many of those resources it is the only available encoding — so pasted real-world material hits this routinely.

## Changes

- **`src/encoding_mappings.py`** — new `IAST_INPUT_ALIASES` map (`ń`→`ṅ`, `Ń`→`Ṅ`), documented and easy to extend with other look-alikes.
- **`src/service.py`** — apply the aliases to the input string in `convert()`, only when the input encoding is IAST, before the main pass.
- **`tests/test_services.py`** — tests covering `ń`→`ṅ` equivalence, uppercase, a full verse line, and that non-IAST input is left untouched.

## Design notes

- **Input-only.** Output stays canonical (`ṅ`); no target encoding changes.
- **Safe.** `ń`/`Ń` are used by none of the schemes (verified), so there is no collision.
- **Scoped to IAST**, where the look-alike actually occurs; other schemes are untouched.

## Testing

All 91 tests pass (86 existing + 5 new).

## Relationship to #7

Same class of problem — input seen in the wild uses a representation the tables don't cover — but an independent fix on its own branch.
